### PR TITLE
#4 Fixed: popup close on clicking the cut button

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -210,7 +210,7 @@
             <div class="content">
                 <header>
                     <p>Add a new note</p>
-                    <i class="uil uil-times"></i>
+                    <i id="closeButton" class="uil uil-times"></i>
                 </header>
                 <form action="#">
                     <div class="row title">
@@ -246,6 +246,12 @@
         addBox.addEventListener('click', () => {
             titleEl.focus();
             popupBox.classList.add('show')
+        });
+
+        // Code to close the popup by click on the cross button
+        let closeBtn = document.getElementById('closeButton');
+        closeBtn.addEventListener('click', ()=>{
+            popupBox.classList.remove('show');
         });
     </script>
 


### PR DESCRIPTION
title: Fixed to close the popup on clicking the cut button

description: The issue to close the popup button has been fixed. Now, Popup will be closed on clicking the cut (x) button

Resolve : #4